### PR TITLE
fix(zsh): add Homebrew completions to FPATH

### DIFF
--- a/.zsh/zshrc/omz.zsh
+++ b/.zsh/zshrc/omz.zsh
@@ -27,4 +27,9 @@ plugins=(
     ssh
 )
 
+# Add Homebrew completions to FPATH before loading Oh My Zsh
+if type brew &>/dev/null; then
+    FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"
+fi
+
 source $ZSH/oh-my-zsh.sh


### PR DESCRIPTION
## What

Add Homebrew's `site-functions` directory to `FPATH` before loading Oh My Zsh, so that shell completions installed via Homebrew (e.g., `gcloudctx`) are picked up by `compinit`.

## Why

Oh My Zsh manages its own `FPATH` and `compinit`, and does not include Homebrew's completion directory by default. This causes completions for Homebrew-installed CLI tools to silently fail while Oh My Zsh plugin-based completions (e.g., `golang`, `kubectl`) continue to work.