### PR TITLE
feat(zsh): integrate kiro cli shell completion

### DIFF
--- a/.zsh/zshrc/amazonq.post.zsh
+++ b/.zsh/zshrc/amazonq.post.zsh
@@ -1,5 +1,0 @@
-#!/usr/bin/env zsh
-
-if "${AMAZONQ_ENABLED}"; then
-    [[ -f "${HOME}/Library/Application Support/amazon-q/shell/zshrc.post.zsh" ]] && builtin source "${HOME}/Library/Application Support/amazon-q/shell/zshrc.post.zsh"
-fi

--- a/.zsh/zshrc/amazonq.pre.zsh
+++ b/.zsh/zshrc/amazonq.pre.zsh
@@ -1,5 +1,0 @@
-#!/usr/bin/env zsh
-
-if "${AMAZONQ_ENABLED}"; then
-    [[ -f "${HOME}/Library/Application Support/amazon-q/shell/zshrc.pre.zsh" ]] && builtin source "${HOME}/Library/Application Support/amazon-q/shell/zshrc.pre.zsh"
-fi

--- a/.zsh/zshrc/kiro.post.zsh
+++ b/.zsh/zshrc/kiro.post.zsh
@@ -1,0 +1,5 @@
+#!/usr/bin/env zsh
+
+if "${KIRO_ENABLED}"; then
+    [[ -f "${HOME}/Library/Application Support/kiro-cli/shell/zshrc.post.zsh" ]] && builtin source "${HOME}/Library/Application Support/kiro-cli/shell/zshrc.post.zsh"
+fi

--- a/.zsh/zshrc/kiro.pre.zsh
+++ b/.zsh/zshrc/kiro.pre.zsh
@@ -1,0 +1,5 @@
+#!/usr/bin/env zsh
+
+if "${KIRO_ENABLED}"; then
+    [[ -f "${HOME}/Library/Application Support/kiro-cli/shell/zshrc.pre.zsh" ]] && builtin source "${HOME}/Library/Application Support/kiro-cli/shell/zshrc.pre.zsh"
+fi

--- a/.zshrc
+++ b/.zshrc
@@ -1,12 +1,14 @@
 #!/usr/bin/env zsh
 
 ZSH_CONFIG_DIR="${HOME}/dotfiles/.zsh/zshrc"
-AMAZONQ_ENABLED=true
+KIRO_ENABLED=true
 
 # Load source files
 source "${ZSH_CONFIG_DIR}/gpg.zsh"
 source "${ZSH_CONFIG_DIR}/arch.zsh"
 source "${ZSH_CONFIG_DIR}/export.zsh"
 source "${ZSH_CONFIG_DIR}/virtualenv.zsh"
+source "${ZSH_CONFIG_DIR}/kiro.pre.zsh"
 source "${ZSH_CONFIG_DIR}/omz.zsh"
+source "${ZSH_CONFIG_DIR}/kiro.post.zsh"
 source "${ZSH_CONFIG_DIR}/alias.zsh"


### PR DESCRIPTION
## What

- Add `.zsh/zshrc/kiro.pre.zsh` and `kiro.post.zsh` that source Kiro CLI's shell hooks under a `KIRO_ENABLED` flag.
- Wire them into `.zshrc` (pre before `omz.zsh`, post after) and rename `AMAZONQ_ENABLED` to `KIRO_ENABLED`.
- Remove the unused `amazonq.{pre,post}.zsh` (never sourced; pointed at the wrong path).

## Why

Kiro CLI was installed but completion did not work because `.zshrc` never sourced the hooks, and the only existing pre/post files targeted the old `amazon-q` path. Kiro's integration requires both pre (registers `fpath`) and post (binds widgets after `compinit`) to run in the right order around Oh My Zsh.