### PR TITLE
Clean up dotfiles for Apple Silicon only setup

### DIFF
--- a/.zsh/dependency-check.zsh
+++ b/.zsh/dependency-check.zsh
@@ -8,7 +8,6 @@ function check_homebrew() {
         echo "Please install Homebrew first!"
         exit 1
     else
-        sleep 1
         echo "Homebrew is already installed!"
     fi
 }
@@ -19,7 +18,6 @@ function check_lsd() {
         echo "Please install lsd first!"
         exit 1
     else
-        sleep 1
         echo "lsd is already installed!"
     fi
 }
@@ -30,7 +28,6 @@ function check_oh_my_zsh() {
         echo "Please install Oh My Zsh first!"
         exit 1
     else
-        sleep 1
         echo "Oh My Zsh is already installed!"
     fi
 }

--- a/.zsh/zshrc/arch.zsh
+++ b/.zsh/zshrc/arch.zsh
@@ -1,14 +1,4 @@
 #!/usr/bin/env zsh
 
-ARCH=$(uname -m)
-if [ "$ARCH" = "arm64" ]; then
-    PR_ARCH="ARM"
-    export BREWx86_BASE=/opt/brew_x86
-    export BREW_BASE=/opt/homebrew
-    export PATH=${BREWx86_BASE}/bin:${BREWx86_BASE}/sbin${PATH:+:${PATH}}
-    export PATH=${BREW_BASE}/bin:${BREW_BASE}/sbin${PATH:+:${PATH}}
-else
-    export BREW_BASE=/opt/brew_x86
-    # export PATH=${BREW_BASE}/bin:${BREW_BASE}/sbin${PATH:+:${PATH}}
-    export PATH=${PATH//¥/homebrew¥//¥/brew_x86¥/}
-fi
+export BREW_BASE=/opt/homebrew
+export PATH=${BREW_BASE}/bin:${BREW_BASE}/sbin${PATH:+:${PATH}}

--- a/.zsh/zshrc/omz.zsh
+++ b/.zsh/zshrc/omz.zsh
@@ -6,24 +6,13 @@ ZSH_THEME="robbyrussell"
 
 plugins=(
     argocd
-    git
-    bundler
-    macos
-    rake
-    rbenv
-    ruby
     aws
     cp
     fzf
     gcloud
     gh
-    golang
-    helm
-    history
-    kind
-    kubectl
     kubectx
-    rails
+    macos
     ssh
 )
 

--- a/install.zsh
+++ b/install.zsh
@@ -16,7 +16,6 @@ function check_os() {
         echo "This script is only for Mac OS X"
         exit 1
     else
-        sleep 1
         echo "This OS is Mac OS X!"
     fi
     if [ "$(uname -m)" != "arm64" ]; then
@@ -24,7 +23,6 @@ function check_os() {
         echo "This script is only for Apple Silicon"
         exit 1
     else
-        sleep 1
         echo "This Mac is Apple Silicon!"
     fi
 }
@@ -35,7 +33,6 @@ function clone_repository() {
         echo "Cloning dotfiles repository..."
         git clone "$GITHUB_REPOSITORY" "$HOME/dotfiles"
     else
-        sleep 1
         echo "dotfiles repository is already cloned!"
     fi
 }
@@ -45,7 +42,6 @@ function install_command_line_tools() {
         echo "Installing Xcode Command Line Tools..."
         xcode-select --install 2>/dev/null
     else
-        sleep 1
         echo "Xcode Command Line Tools is already installed!"
     fi
 }
@@ -55,7 +51,6 @@ function install_homebrew() {
         echo "Installing Homebrew for Apple Silicon..."
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" 2>/dev/null
     else
-        sleep 1
         echo "Homebrew for Apple Silicon is already installed!"
     fi
 }
@@ -65,7 +60,6 @@ function install_oh_my_zsh() {
         echo "Installing Oh My Zsh..."
         sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
     else
-        sleep 1
         echo "Oh My Zsh is already installed!"
     fi
 }

--- a/install/symlink.zsh
+++ b/install/symlink.zsh
@@ -13,7 +13,7 @@ ln -nfs "${HOME}/dotfiles/.config/gh" "${HOME}/.config/gh"
 # Clone directly: git clone git@github.com:Okabe-Junya/claude-config.git ~/.claude
 
 # zshrc
-if [ -f "${HOME}/.zshrc" ]; then
+if [ -f "${HOME}/.zshrc" ] && [ ! -L "${HOME}/.zshrc" ]; then
     mv "${HOME}/.zshrc" "${HOME}/.zshrc.bak"
 fi
 ln -nfs "${HOME}/dotfiles/.zshrc" "${HOME}/.zshrc"


### PR DESCRIPTION
## What

- Remove x86 Homebrew support from `arch.zsh` (dead code, `/opt/brew_x86` does not exist)
- Remove unnecessary `sleep 1` calls from `install.zsh` and `dependency-check.zsh`
- Make `symlink.zsh` idempotent by only backing up `.zshrc` when it is a regular file, not an existing symlink
- Remove alias-heavy and unused Oh My Zsh plugins:
  - Ruby-related: `bundler`, `rake`, `rbenv`, `ruby`, `rails`
  - Alias-heavy with Homebrew completions available: `git` (197 aliases), `kubectl` (116), `golang` (26), `kind` (7), `helm` (5), `history` (4)

## Why

- x86 Homebrew is no longer needed on Apple Silicon Macs in 2026
- `sleep 1` calls add ~6s of unnecessary delay during installation
- Repeated `symlink.zsh` runs overwrite the backup with the symlink itself
- Removed OMZ plugins either define unwanted aliases or are unused; completions for `kubectl`, `helm`, `kind`, etc. are already provided by Homebrew via `FPATH`