### PR TITLE
Fix config issues and add missing Brewfile entries

### DIFF
--- a/.config/git/.gitconfig
+++ b/.config/git/.gitconfig
@@ -28,7 +28,5 @@
 
 [pager]
         difftool = true
-[http]
-	cookiefile = abc
 [commit]
 	gpgsign = true

--- a/.zsh/zshrc/kiro.post.zsh
+++ b/.zsh/zshrc/kiro.post.zsh
@@ -1,5 +1,5 @@
 #!/usr/bin/env zsh
 
-if "${KIRO_ENABLED}"; then
+if [[ "${KIRO_ENABLED}" == "true" ]]; then
     [[ -f "${HOME}/Library/Application Support/kiro-cli/shell/zshrc.post.zsh" ]] && builtin source "${HOME}/Library/Application Support/kiro-cli/shell/zshrc.post.zsh"
 fi

--- a/.zsh/zshrc/kiro.pre.zsh
+++ b/.zsh/zshrc/kiro.pre.zsh
@@ -1,5 +1,5 @@
 #!/usr/bin/env zsh
 
-if "${KIRO_ENABLED}"; then
+if [[ "${KIRO_ENABLED}" == "true" ]]; then
     [[ -f "${HOME}/Library/Application Support/kiro-cli/shell/zshrc.pre.zsh" ]] && builtin source "${HOME}/Library/Application Support/kiro-cli/shell/zshrc.pre.zsh"
 fi

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DEFAULT: install-all
+.DEFAULT_GOAL := install-all
 
 .PHONY: install-all
 install-all:

--- a/install/Brewfile
+++ b/install/Brewfile
@@ -63,6 +63,10 @@ brew "git"
 brew "git-lfs"
 brew "ghq"
 
+# Diff and documentation tools
+brew "difftastic"
+brew "glow"
+
 # Multimedia tools
 brew "ffmpeg"
 


### PR DESCRIPTION
## What

- Remove invalid `http.cookiefile = abc` from `.gitconfig`
- Fix `KIRO_ENABLED` condition to use `[[ == ]]` string comparison instead of executing the variable as a command
- Use `.DEFAULT_GOAL` instead of a pseudo-target `DEFAULT` in Makefile
- Add `difftastic` and `glow` to Brewfile (used by `.gitconfig` and `alias.zsh` respectively)

## Why

- `cookiefile = abc` is not a valid path and has no effect
- `if "${KIRO_ENABLED}"` executes `"true"` as a command, which works by accident on macOS but fails if the variable is unset or `"false"`
- `DEFAULT: install-all` defines a target named `DEFAULT`, not the Make default goal; reordering targets would break `make` with no arguments
- New machines running `brew bundle` would lack `difftastic` and `glow`, causing broken git diff and `mdpreview` alias