### PR TITLE
Improve zsh startup speed with lazy init and fixed paths

### DIFF
--- a/.zsh/zshrc/omz.zsh
+++ b/.zsh/zshrc/omz.zsh
@@ -28,8 +28,6 @@ plugins=(
 )
 
 # Add Homebrew completions to FPATH before loading Oh My Zsh
-if type brew &>/dev/null; then
-    FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"
-fi
+FPATH="/opt/homebrew/share/zsh/site-functions:${FPATH}"
 
 source $ZSH/oh-my-zsh.sh

--- a/.zsh/zshrc/virtualenv.zsh
+++ b/.zsh/zshrc/virtualenv.zsh
@@ -1,13 +1,28 @@
 #!/usr/bin/env zsh
 
+# Lazy initialization for version managers to speed up shell startup.
+# The wrapper function is replaced by the real init on first invocation.
+
 if command -v pyenv 1>/dev/null 2>&1; then
-    eval "$(pyenv init -)"
+    pyenv() {
+        unfunction pyenv
+        eval "$(command pyenv init -)"
+        pyenv "$@"
+    }
 fi
 if command -v nodenv 1>/dev/null 2>&1; then
-    eval "$(nodenv init -)"
+    nodenv() {
+        unfunction nodenv
+        eval "$(command nodenv init -)"
+        nodenv "$@"
+    }
 fi
 if command -v rbenv 1>/dev/null 2>&1; then
-    eval "$(rbenv init -)"
+    rbenv() {
+        unfunction rbenv
+        eval "$(command rbenv init -)"
+        rbenv "$@"
+    }
 fi
 if command -v direnv 1>/dev/null 2>&1; then
     eval "$(direnv hook zsh)"


### PR DESCRIPTION
## What

- Replace `brew --prefix` subshell call with fixed `/opt/homebrew` path in `omz.zsh`
- Lazy-initialize `pyenv`, `nodenv`, and `rbenv` — defer `eval "$(xxx init -)"` until first invocation

## Why

- `brew --prefix` spawns a subprocess on every shell startup (~100ms). Since this repo targets Apple Silicon only, the path is always `/opt/homebrew`
- `pyenv init`, `nodenv init`, `rbenv init` each take 50-150ms. With lazy init, the cost is deferred to first use, saving ~200-400ms on shell startup
- `direnv` is not lazy-initialized because it needs to register a `chpwd` hook immediately