### PR TITLE
Pin GitHub Actions to SHA digests with semver comments

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -49,7 +49,7 @@
       "matchDepTypes": [
         "action"
       ],
-      "pinDigests": false
+      "pinDigests": true
     }
   ]
 }

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,4 +9,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v6
+      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: shellcheck
-        uses: reviewdog/action-shellcheck@v1
+        uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e # v1.32.0
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Run tests
         run: ./install.zsh --non-interactive
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Run tests
         run: curl -L https://raw.githubusercontent.com/Okabe-Junya/dotfiles/main/install.zsh | zsh -s -- --non-interactive


### PR DESCRIPTION
## What

- Pin all GitHub Actions to their full commit SHA digests instead of mutable version tags
- Add semver version comments (e.g., `# v4.3.1`) alongside each SHA for readability
- Update Renovate config to enable `pinDigests: true` for actions (was `false`)

### Actions pinned

| Action | Version | SHA |
|--------|---------|-----|
| `actions/checkout` | v4.3.1 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/labeler` | v6.0.1 | `634933edcd8ababfe52f92936142cc22ac488b1b` |
| `reviewdog/action-shellcheck` | v1.32.0 | `4c07458293ac342d477251099501a718ae5ef86e` |

## Why

- **Supply chain security**: Version tags (e.g., `v4`) are mutable — a compromised upstream could retag to a malicious commit. SHA pinning ensures immutability.
- **Renovate compatibility**: With `pinDigests: true` and the `# vX.Y.Z` comment format, Renovate can automatically update both the SHA and version comment when new releases are available.
- The previous `pinDigests: false` setting was explicitly disabling this security feature.