### PR TITLE
Fix install.zsh to work reliably on a fresh Mac

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,13 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Run tests
-        run: curl -L https://raw.githubusercontent.com/Okabe-Junya/dotfiles/main/install.zsh | zsh -s -- --non-interactive
+      - name: Serve install.zsh locally
+        run: |
+          python3 -m http.server 8888 &
+          sleep 1
+        shell: zsh {0}
+
+      - name: Run remote-style installation
+        run: curl -L http://localhost:8888/install.zsh | zsh -s -- --non-interactive
         shell: zsh {0}
         timeout-minutes: 60

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,14 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Run tests
-        run: ./install.zsh --non-interactive
+      - name: Run install script
+        run: ./install.zsh --non-interactive --skip-brew-bundle
         shell: zsh {0}
-        timeout-minutes: 60
+        timeout-minutes: 10
+
+      - name: Validate Brewfile
+        run: brew bundle list --file=install/Brewfile > /dev/null
+        shell: zsh {0}
 
   readme-installation-test:
     runs-on: macos-latest
@@ -35,6 +39,10 @@ jobs:
         shell: zsh {0}
 
       - name: Run remote-style installation
-        run: curl -L http://localhost:8888/install.zsh | zsh -s -- --non-interactive
+        run: curl -L http://localhost:8888/install.zsh | zsh -s -- --non-interactive --skip-brew-bundle
         shell: zsh {0}
-        timeout-minutes: 60
+        timeout-minutes: 10
+
+      - name: Validate Brewfile
+        run: brew bundle list --file=$HOME/dotfiles/install/Brewfile > /dev/null
+        shell: zsh {0}

--- a/install.zsh
+++ b/install.zsh
@@ -3,12 +3,13 @@
 set -euo pipefail
 
 NON_INTERACTIVE=false
+SKIP_BREW_BUNDLE=false
 
 for arg in "$@"; do
-    if [ "$arg" = "--non-interactive" ]; then
-        NON_INTERACTIVE=true
-        break
-    fi
+    case "$arg" in
+        --non-interactive) NON_INTERACTIVE=true ;;
+        --skip-brew-bundle) SKIP_BREW_BUNDLE=true ;;
+    esac
 done
 
 function check_os() {
@@ -59,6 +60,11 @@ function install_oh_my_zsh() {
 }
 
 function brew_bundle_install() {
+    if [ "$SKIP_BREW_BUNDLE" = true ]; then
+        echo "Skipping Homebrew Bundle installation (--skip-brew-bundle)"
+        return
+    fi
+
     echo "Installing Homebrew Bundle..."
     if [ "$NON_INTERACTIVE" = true ]; then
         echo "Skipping interactive prompt and installing Homebrew Bundle..."

--- a/install.zsh
+++ b/install.zsh
@@ -27,78 +27,67 @@ function check_os() {
     fi
 }
 
-function clone_repository() {
-    GITHUB_REPOSITORY="https://github.com/Okabe-Junya/dotfiles"
-    if [ ! -d "$HOME/dotfiles" ]; then
-        echo "Cloning dotfiles repository..."
-        git clone "$GITHUB_REPOSITORY" "$HOME/dotfiles"
-    else
-        echo "dotfiles repository is already cloned!"
-    fi
-}
-
-function install_command_line_tools() {
-    if [ ! -d "/Library/Developer/CommandLineTools" ]; then
-        echo "Installing Xcode Command Line Tools..."
-        xcode-select --install 2>/dev/null
-    else
-        echo "Xcode Command Line Tools is already installed!"
-    fi
-}
-
 function install_homebrew() {
     if [ ! -d "/opt/homebrew" ]; then
         echo "Installing Homebrew for Apple Silicon..."
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" 2>/dev/null
+        NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     else
         echo "Homebrew for Apple Silicon is already installed!"
+    fi
+    # Ensure brew is available in the current session
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+}
+
+function clone_repository() {
+    if [ ! -d "$HOME/dotfiles" ]; then
+        echo "Cloning dotfiles repository..."
+        git clone "https://github.com/Okabe-Junya/dotfiles" "$HOME/dotfiles"
+    else
+        echo "dotfiles repository is already cloned!"
     fi
 }
 
 function install_oh_my_zsh() {
     if [ ! -d "$HOME/.oh-my-zsh" ]; then
         echo "Installing Oh My Zsh..."
-        sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+        # --unattended: skip changing default shell and running zsh after install
+        # --keep-zshrc: do not overwrite existing .zshrc
+        sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended --keep-zshrc
     else
         echo "Oh My Zsh is already installed!"
     fi
 }
 
-function initialize_symbolic_links() {
-    echo "Initializing symbolic links..."
-    source "./install/symlink.zsh"
-}
-
 function brew_bundle_install() {
     echo "Installing Homebrew Bundle..."
-    current_dir=$(pwd)
-    cd "$HOME/dotfiles"
-
     if [ "$NON_INTERACTIVE" = true ]; then
         echo "Skipping interactive prompt and installing Homebrew Bundle..."
-        brew bundle install --file="./install/Brewfile"
+        brew bundle install --file="$HOME/dotfiles/install/Brewfile"
     else
         echo -n "Do you want to install Homebrew Bundle? [y/n]: "
         read answer
         case $answer in
         [yY]*)
-            brew bundle install --file="./install/Brewfile"
+            brew bundle install --file="$HOME/dotfiles/install/Brewfile"
             ;;
         *)
             echo "Homebrew Bundle is not installed!"
             ;;
         esac
     fi
-    cd "$current_dir"
+}
+
+function initialize_symbolic_links() {
+    echo "Initializing symbolic links..."
+    source "$HOME/dotfiles/install/symlink.zsh"
 }
 
 function install() {
     check_os
-    clone_repository
-    install_command_line_tools
     install_homebrew
-    install_oh_my_zsh
+    clone_repository
     brew_bundle_install
+    install_oh_my_zsh
     initialize_symbolic_links
 
     echo "Installation is complete!"


### PR DESCRIPTION
## What

- Remove `install_command_line_tools` — Homebrew installer handles CLT automatically
- Add `eval "$(/opt/homebrew/bin/brew shellenv)"` after Homebrew install so `brew` is available in the current session
- Add `NONINTERACTIVE=1` to Homebrew installer to suppress interactive prompts
- Add `--unattended --keep-zshrc` to Oh My Zsh installer to prevent `.zshrc` overwrite and `exec zsh` interruption
- Replace all relative paths (`./install/...`) with absolute paths (`$HOME/dotfiles/...`) so `curl | zsh` works regardless of working directory
- Reorder install steps: `homebrew → clone → brew_bundle → omz → symlink` to respect dependencies
- Fix CI `readme-installation-test` to test the current branch's `install.zsh` instead of always fetching from `main`

## Why

Running `curl -L .../install.zsh | zsh -s -- --non-interactive` on a fresh Apple Silicon Mac failed because:
1. `xcode-select --install` opens a GUI dialog and returns immediately — the script continued before CLT was ready
2. After Homebrew install, `brew` was not in PATH for the current session
3. Oh My Zsh installer overwrote `~/.zshrc` with its own template, then attempted `exec zsh` which aborted the script under `set -e`
4. `source "./install/symlink.zsh"` failed when the working directory was not `$HOME/dotfiles` (as in `curl | zsh`)
5. CI always tested the `main` branch's `install.zsh`, so these bugs were never caught in PRs