### PR TITLE
Add macOS system preferences management via defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ dependency-check:
 	@echo "Checking dependencies"
 	./.zsh/dependency-check.zsh
 
+.PHONY: macos
+macos:
+	@echo "Applying macOS system preferences"
+	./install/macos.zsh
+
 .PHONY: help
 help:
 	@echo "Usage: make [target]"
@@ -23,4 +28,5 @@ help:
 	@echo "  install-all: Install all dependencies and setup"
 	@echo "  symlink: Create symlinks"
 	@echo "  dependency-check: Check dependencies"
+	@echo "  macos: Apply macOS system preferences"
 	@echo "  help: Show this help message"

--- a/install.zsh
+++ b/install.zsh
@@ -69,6 +69,11 @@ function initialize_symbolic_links() {
     source "./install/symlink.zsh"
 }
 
+function configure_macos() {
+    echo "Configuring macOS system preferences..."
+    source "./install/macos.zsh"
+}
+
 function brew_bundle_install() {
     echo "Installing Homebrew Bundle..."
     current_dir=$(pwd)
@@ -100,6 +105,7 @@ function install() {
     install_oh_my_zsh
     brew_bundle_install
     initialize_symbolic_links
+    configure_macos
 
     echo "Installation is complete!"
 }

--- a/install.zsh
+++ b/install.zsh
@@ -89,8 +89,13 @@ function initialize_symbolic_links() {
 }
 
 function configure_macos() {
-    echo "Configuring macOS system preferences..."
-    source "$HOME/dotfiles/install/macos.zsh"
+    local macos_script="$HOME/dotfiles/install/macos.zsh"
+    if [ -f "$macos_script" ]; then
+        echo "Configuring macOS system preferences..."
+        source "$macos_script"
+    else
+        echo "macOS preferences script not found, skipping..."
+    fi
 }
 
 function install() {

--- a/install/macos.zsh
+++ b/install/macos.zsh
@@ -1,0 +1,62 @@
+#!/usr/bin/env zsh
+
+# macOS system preferences managed via `defaults write`
+# Intended for Apple Silicon Macs running macOS Sequoia or later
+
+set -euo pipefail
+
+echo "Applying macOS system preferences..."
+
+# =============================================================================
+# Appearance
+# =============================================================================
+
+# Dark mode
+defaults write NSGlobalDomain AppleInterfaceStyle -string "Dark"
+
+# =============================================================================
+# Dock
+# =============================================================================
+
+# Icon size (pixels)
+defaults write com.apple.dock tilesize -int 64
+
+# =============================================================================
+# Finder
+# =============================================================================
+
+# Default view style: list view
+# Nlsv = list, icnv = icon, clmv = column, glyv = gallery
+defaults write com.apple.finder FXPreferredViewStyle -string "Nlsv"
+
+# =============================================================================
+# Keyboard
+# =============================================================================
+
+# Key repeat rate (lower = faster, default: 6)
+defaults write NSGlobalDomain KeyRepeat -int 2
+
+# Delay until key repeat (lower = shorter, default: 25)
+defaults write NSGlobalDomain InitialKeyRepeat -int 15
+
+# =============================================================================
+# Hot Corners
+# =============================================================================
+
+# Bottom-right corner: Quick Note (14)
+#   0: no action, 2: Mission Control, 3: App Windows,
+#   4: Desktop, 5: Screen Saver (start), 6: Screen Saver (disable),
+#   10: Put Display to Sleep, 11: Launchpad, 12: Notification Center,
+#   13: Lock Screen, 14: Quick Note
+defaults write com.apple.dock wvous-br-corner -int 14
+defaults write com.apple.dock wvous-br-modifier -int 0
+
+# =============================================================================
+# Apply changes
+# =============================================================================
+
+killall Dock 2>/dev/null || true
+killall Finder 2>/dev/null || true
+killall SystemUIServer 2>/dev/null || true
+
+echo "macOS system preferences applied!"


### PR DESCRIPTION
## What

- Add `install/macos.zsh` to manage macOS system preferences via `defaults write`
- Add `make macos` target for standalone execution
- Integrate into `install.zsh` full setup flow

### Managed settings

| Setting | Value |
|---|---|
| Appearance | Dark mode |
| Dock tile size | 64px |
| Finder default view | List view |
| Key repeat rate | 2 (fast) |
| Initial key repeat delay | 15 (fast) |
| Hot corner (bottom-right) | Quick Note |

## Why

macOS system preferences are lost on a fresh setup or machine migration. Managing them as code in the dotfiles repo ensures reproducibility across Apple Silicon Macs.