### PR TITLE
Stop tracking gh hosts.yml to prevent token exposure

### DIFF
--- a/.config/gh/hosts.yml
+++ b/.config/gh/hosts.yml
@@ -1,5 +1,0 @@
-github.com:
-    user: Okabe-Junya
-    git_protocol: https
-    users:
-        Okabe-Junya:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ vendor/
 
 .config/*
 !.config/gh/
+# gh writes auth tokens into hosts.yml when the OS keyring is unavailable; never
+# track it in this public repo. Only config.yml (no secrets) is versioned.
+.config/gh/hosts.yml
 !.config/git/
 !.config/latex/
 !.config/claude/


### PR DESCRIPTION
## What

Stop version-tracking `.config/gh/hosts.yml` in this public repo: add it to `.gitignore` and `git rm --cached` it. `.config/gh/config.yml` (no secrets) stays tracked.

## Why

`gh` writes the OAuth token into `hosts.yml` whenever the OS keyring is unavailable. The repo is public and the `.gitignore` whitelisted the entire `.config/gh/` directory, so a token written there would be committed and become world-readable on the next `git add`. The tracked `hosts.yml` currently holds only an empty user entry (no token), so this is preventive — it closes the path before a token can ever land. The setup symlink points `~/.config/gh` at the repo directory, so `gh` still writes `hosts.yml` there at runtime; it is now simply gitignored.