### PR TITLE
Stop ignoring CLAUDE.md in the global gitignore

### DIFF
--- a/.config/git/ignore
+++ b/.config/git/ignore
@@ -2,6 +2,5 @@
 .ipynb_checkpoints
 .envrc
 .junya-okabe
-CLAUDE.md
 .mcp.json
 **/.claude/settings.local.json


### PR DESCRIPTION
## What

Remove `CLAUDE.md` from the global git ignore file (`.config/git/ignore`).

## Why

Project-specific agent instructions now live as per-repo `CLAUDE.md` files committed to each repository, so they should be trackable. Ignoring them globally kept them machine-local and easy to lose on re-clone.
